### PR TITLE
Fixed bunyip to use the new yeti API

### DIFF
--- a/lib/bunyip.js
+++ b/lib/bunyip.js
@@ -8,7 +8,7 @@
  */
 
 var util = require('util'),
-	yeti = require("../node_modules/yeti/lib/cli").route,
+	yeti = require("../node_modules/yeti/lib/cli"),
 	fs = require("fs"),
 	BrowserStack = require("./browserstack"),
 	LocalBrowsers = require("./localbrowsers"),
@@ -94,7 +94,15 @@ exports.route = function(program) {
 		}
 	} else if(program.file) {
 		try {
-			yeti(["","", program.file, "--port=" + program.port]);
+			var yetiConf = {
+				stdin: process.stdin,
+				stdout: process.stdout,
+				stderr: process.stderr,
+				exitFn: process.exit
+			};
+			var cli = new yeti.CLI(yetiConf);
+			cli.route(["","", program.file, "--port=" + program.port]);
+
 		} catch(e) {
 			console.log(e);
 		}
@@ -111,13 +119,9 @@ exports.route = function(program) {
 			program.commands.forEach(function(cmd, i){
 				// cmd.isSet idea taken from https://github.com/jayarjo/bunyip/
 				if(cmd.isSet) {
-					if(cmd.name === "local") {
-						lb = new LocalBrowsers(config, program.port);
-
-						lb.launchBrowsers(cmd.launch);
-
-						process.on('exit', lb.exitBrowsers);
-					}
+					lb = new LocalBrowsers(config, program.port);
+					lb.launchBrowsers(cmd.launch);
+					process.on('exit', lb.exitBrowsers);
 				}
 			});
 		});

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "commander": "0.6.x",
 	  "browserstack": "0.1.x",
-	  "yeti": "0.2.x"
+	  "yeti": ">=0.2.12"
   },
   "devDependencies": {
     "grunt": "~0.3.9",


### PR DESCRIPTION
# Yeti fix

npm update updated yeti and it broke bunyip, since the API bunyip was using is now gone. This fixes it. 
## Tested with
### Os X Mountain Lion 10.8.2
- node v0.8.12
### Linux Red Hat Server 6.2
- node v0.8.9
