### PR TITLE
Use Program Files(x86) on Windows x64. Fixes ryanseddon / bunyip #18

### DIFF
--- a/lib/localbrowsers.js
+++ b/lib/localbrowsers.js
@@ -1,4 +1,5 @@
 var fs = require("fs"),
+    os = require("os"),
     exec = require('child_process').exec;
 
 function LocalBrowsers(config, port) {
@@ -11,21 +12,22 @@ function LocalBrowsers(config, port) {
         cmdPrefix = "open -n -g -a",
         cmdPrefixLinux = "exec",
         activeBrowsers = {},
+        programFiles = os.arch() === "x64" ? process.env["ProgramFiles(x86)"] : process.env.ProgramFiles,
         browsers = {
             firefox: {
                 name: "Firefox",
-                win32: '"' + process.env.ProgramFiles + '\\Mozilla Firefox\\firefox.exe' + '"',
+                win32: '"' + programFiles + '\\Mozilla Firefox\\firefox.exe' + '"',
                 darwin: cmdPrefix + ' Firefox --args',
                 linux: cmdPrefixLinux + ' firefox '
             },
             firefoxaurora: {
                 name: "Firefox Aurora",
-                win32: '"' + process.env.ProgramFiles + '\\Aurora\\firefox.exe' + '"',
+                win32: '"' + programFiles + '\\Aurora\\firefox.exe' + '"',
                 darwin: cmdPrefix + ' FirefoxAurora --args'
             },
             firefoxnightly: {
                 name: "Firefox Nightly",
-                win32: '"' + process.env.ProgramFiles + '\\Firefox Nightly\\firefox.exe' + '"',
+                win32: '"' + programFiles + '\\Firefox Nightly\\firefox.exe' + '"',
                 darwin: cmdPrefix + ' Nightly --args'
             },
             chrome: {
@@ -41,22 +43,22 @@ function LocalBrowsers(config, port) {
             },
             opera: {
                 name: "Opera",
-                win32: '"' + process.env.ProgramFiles + '\\Opera\\opera.exe' + '"',
+                win32: '"' + programFiles + '\\Opera\\opera.exe' + '"',
                 darwin: cmdPrefix + ' Opera --args',
                 linux: cmdPrefixLinux+ ' opera '
             },
             operanext: {
                 name: "Opera Next",
-                win32: '"' + process.env.ProgramFiles + '\\Opera Next x64\\opera.exe' + '"',
+                win32: '"' + programFiles + '\\Opera Next x64\\opera.exe' + '"',
                 darwin: cmdPrefix + ' "Opera Next" --args'
             },
             safari: {
                 name: "Safari",
-                win32: '"' + process.env.ProgramFiles + '\\Safari\\safari.exe' + '"',
+                win32: '"' + programFiles + '\\Safari\\safari.exe' + '"',
                 darwin: cmdPrefix + ' Safari'
             },
             ie: {
-                win32: '"' + process.env.ProgramFiles + '\\Internet Explorer\\iexplore.exe' + '"'
+                win32: '"' + programFiles + '\\Internet Explorer\\iexplore.exe' + '"'
             },
             phantomjs: {
                 name: "phantomjs",


### PR DESCRIPTION
%Program Files(x86)% makes more sense on Windows x64 since most of the browsers on Windows still support 32-bit applications only, and Program Files(x86) is the default installation location for 32-bit apps on 64-bit Windows. 
